### PR TITLE
manifest: Link qssi_bt Android.bp

### DIFF
--- a/snippets/hardware.xml
+++ b/snippets/hardware.xml
@@ -31,6 +31,8 @@
     <linkfile src="os_pickup.mk" dest="vendor/nxp/opensource/pn5xx/Android.mk" />
     <linkfile src="os_pickup.bp" dest="vendor/nxp/opensource/sn100x/Android.bp" />
     <linkfile src="os_pickup.mk" dest="vendor/nxp/opensource/sn100x/Android.mk" />
+    <!-- add namespace for BT adv audio, as required for QTI BT stack -->
+    <linkfile src="os_pickup_qssi_bt.bp" dest="device/qcom/qssi/Android.bp" />
   </project>
   <!--project path="hardware/qcom-caf/msm8996/audio" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" remote="arrow" revision="arrow-12.0-caf-msm8996" />
   <project path="hardware/qcom-caf/msm8996/display" name="android_hardware_qcom_display" groups="pdk,qcom,qcom_display" remote="arrow" revision="arrow-12.0-caf-msm8996" />


### PR DESCRIPTION
issue:
vendor/qcom/opensource/commonsys/bluetooth_ext/system_bt_ext/btif/Android.bp:2:9: module "device_qcom_qssi_Android_bpsoong_config_module_type_import_0xc004a2c000": from: failed to open "device/qcom/qssi/Android.bp": open /datadrive/arcana/device/qcom/qssi/Android.bp: no such file or directory
vendor/qcom/opensource/commonsys/bluetooth_ext/system_bt_ext/btif/Android.bp:8:1: unrecognized module type "bredr_vs_btadva_cc_defaults"